### PR TITLE
Fixed bug in safari and added in support for operator buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ adding a reference to [mathquill4quill.js](https://github.com/c-w/mathquill4quil
 
 Next, initialize your Quill object and load the formula module:
 
-```js
+```javascript
 // setup quill with formula support
 
 var quill = new Quill('#editor', {
@@ -36,8 +36,18 @@ var quill = new Quill('#editor', {
 
 Last step: replace Quill's native formula authoring with MathQuill.
 
-```js
+```javascript
 // enable mathquill formula editor
 
 quill.enableMathQuillFormulaAuthoring();
 ```
+
+You can also add in operator buttons(buttons that allow users not familiar with latex to add in operators/functions like square roots) to the editor by passing an `operators` variable to the `enableMathQuillFormulaAuthoring()` function. Example:
+
+```javascript
+quill.enableMathQuillFormulaAuthoring({
+    operators:[["\\sqrt[n]{x}","\\nthroot"]]
+});
+```
+
+The operators variable is an array of arrays. The outside array contains all of the different arrays which describe the operator buttons. The arrays inside of the main array consist of two values. The first value is the latex that gets rendered as the value on the button, and the second value is the latex that gets inserted into the MathQuill editor. 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MathQuill 4 Quill #
+# MathQuill 4 Quill
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/c-w/mathquill4quill/blob/master/LICENSE.txt)
 
-## What's this? ##
+## What's this?
 
 This module adds support for rich math authoring to the
 [Quill](http://quilljs.com/) editor.
@@ -11,7 +11,7 @@ This module adds support for rich math authoring to the
 
 [Live demo](https://c-w.github.io/mathquill4quill/)
 
-## Usage example ##
+## Usage example
 
 This module depends on
 [MathQuill](http://docs.mathquill.com/en/latest/Getting_Started/),
@@ -41,4 +41,3 @@ Last step: replace Quill's native formula authoring with MathQuill.
 
 quill.enableMathQuillFormulaAuthoring();
 ```
-

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -99,6 +99,18 @@
     getTooltipSaveButton(this).addEventListener("click", function() {
       mqField.latex("");
     });
+
+    //add handler to toolbar to fix functionality in safari
+    if(Boolean(window.safari))
+    {
+      var toolbar = this.getModule("toolbar");
+      toolbar.addHandler("formula", function() {
+        var inputBox = document.getElementsByClassName("ql-tooltip")[0];
+        inputBox.setAttribute("data-mode", "formula");
+        inputBox.className += " ql-editing ql-flip";
+        inputBox.classList.remove("ql-hidden");
+      });
+    }
   };
 
 })(window.Quill, window.MathQuill);

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -32,6 +32,12 @@
     mqInput.style.width = "170px";
   }
 
+  function applyButtonStyles(button) {
+    button.style.margin = "5px";
+    button.style.width = "50px";
+    button.style.height = "50px";
+  }
+
   function getTooltipElement(quill) {
     return quill.container.getElementsByClassName("ql-tooltip")[0];
   }
@@ -46,12 +52,26 @@
     return tooltip.getElementsByClassName("ql-action")[0];
   }
 
-  Quill.prototype.enableMathQuillFormulaAuthoring = function() {
+  function getOperatorButton(displayOperator, operator, mathquill) {
+    var button = document.createElement("button");
+    katex.render(displayOperator, button, {
+      throwOnError: false
+    });
+    button.onclick = function()
+    {
+      mathquill.cmd(operator);
+      mathquill.focus();
+    }
+    applyButtonStyles(button);
+    return button;
+  }
+
+  Quill.prototype.enableMathQuillFormulaAuthoring = function(options) {
     if (!areAllDependenciesMet(this)) {
       return;
     }
 
-    // replace LaTeX formula input wiht MathQuill input
+    // replace LaTeX formula input with MathQuill input
     var latexInput = getTooltipLatexFormulaInput(this);
     latexInput.style.display = "none";
     var mqInput = document.createElement("span");
@@ -66,6 +86,14 @@
         }
       }
     });
+
+    if(options && options.operators)
+    {
+      latexInput.parentNode.appendChild(document.createElement("br"));
+      options.operators.forEach(function(element) {
+        latexInput.parentNode.appendChild(getOperatorButton(element[0], element[1], mqField));
+      });
+    }
 
     // don't show the old math when the tooltip gets opened next time
     getTooltipSaveButton(this).addEventListener("click", function() {


### PR DESCRIPTION
Issue #1 in this repository was about the formula editor not opening in safari. This PR fixes this issue by implementing the fix that was linked to in that issue. This is a fix, but it does sacrifice some functionality, mainly the fact that positioning the formula editor is not yet implemented on safari. 

This PR also adds in support for operator buttons, buttons that allow for users that are not familiar with latex to add in operators like square roots, fractions, and others. The method for adding in these buttons is by passing an array of arrays into the `enableMathQuillFormulaAuthoring()` function. This way of adding in operator buttons probably needs to be changed, but I did not know the best format to keep consistency with the rest of the project/Quill/MathQuill. The styling on these buttons probably also needs to be changed and I would appreciate some guidance with that.