### PR TITLE
Updated styling on buttons and fixed safari positioning

### DIFF
--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -74,6 +74,10 @@
     return button;
   }
 
+  function isSafari() {
+    return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  }
+
   Quill.prototype.enableMathQuillFormulaAuthoring = function(options) {
     if (!areAllDependenciesMet(this)) {
       return;
@@ -108,7 +112,7 @@
     });
 
     //add handler to toolbar to fix functionality in safari
-    if (window.safari) {
+    if (isSafari()) {
       var toolbar = this.getModule("toolbar");
       toolbar.addHandler("formula", function() {
         var inputBox = document.getElementsByClassName("ql-tooltip")[0];

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -81,10 +81,10 @@
 
     // replace LaTeX formula input with MathQuill input
     var latexInput = getTooltipLatexFormulaInput(this);
-    latexInput.setAttribute("style","visiblity:hidden;padding:0px;border:0px;width:0px;");
     var mqInput = document.createElement("span");
     applyInputStyles(mqInput);
     insertAfter(mqInput, latexInput);
+    latexInput.setAttribute("style","visibility:hidden;padding:0px;border:0px;width:0px;");
 
     // synchronize MathQuill input and LaTeX formula input
     var mqField = MathQuill.getInterface(2).MathField(mqInput, {

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -41,6 +41,10 @@
     button.style.margin = "5px";
     button.style.width = "50px";
     button.style.height = "50px";
+    button.style.backgroundColor = "#ffffff";
+    button.style.borderColor = "#000000"
+    button.style.borderRadius = "7px";
+    button.style.borderWidth = "2px";
   }
 
   function getTooltipElement(quill) {

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -74,10 +74,6 @@
     return button;
   }
 
-  function isSafari() {
-    return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-  }
-
   Quill.prototype.enableMathQuillFormulaAuthoring = function(options) {
     if (!areAllDependenciesMet(this)) {
       return;
@@ -85,7 +81,7 @@
 
     // replace LaTeX formula input with MathQuill input
     var latexInput = getTooltipLatexFormulaInput(this);
-    latexInput.style.display = "none";
+    latexInput.setAttribute("style","visiblity:hidden;padding:0px;border:0px;width:0px;");
     var mqInput = document.createElement("span");
     applyInputStyles(mqInput);
     insertAfter(mqInput, latexInput);
@@ -110,17 +106,6 @@
     getTooltipSaveButton(this).addEventListener("click", function() {
       mqField.latex("");
     });
-
-    //add handler to toolbar to fix functionality in safari
-    if (isSafari()) {
-      var toolbar = this.getModule("toolbar");
-      toolbar.addHandler("formula", function() {
-        var inputBox = document.getElementsByClassName("ql-tooltip")[0];
-        inputBox.setAttribute("data-mode", "formula");
-        inputBox.className += " ql-editing ql-flip";
-        inputBox.classList.remove("ql-hidden");
-      });
-    }
   };
 
 })(window.Quill, window.MathQuill, window.katex);


### PR DESCRIPTION
This pull request includes a restyling of the buttons to better match the styling of the quill editor's snow theme. Maybe integration with quill's theming in the future would be something to consider.
New Buttons:
![new](https://user-images.githubusercontent.com/39388941/59544253-32977900-8ec5-11e9-97fe-ed32271ed452.png)
Old Buttons:
![old](https://user-images.githubusercontent.com/39388941/59544256-37f4c380-8ec5-11e9-952f-529c34a0fac6.png)
This PR also contains a more complete fix for safari, changing around the CSS styling a little bit to make the tooltip display(I have no idea why this works). Maybe time for v0.0.2 if this gets merged.
