### PR TITLE
Fixed positioning of operator buttons.

### DIFF
--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -99,11 +99,14 @@
 
     if (options && options.operators) {
       latexInput.parentNode.appendChild(document.createElement("br"));
+      var container = document.createElement("div");
+      container.setAttribute("style","display:flex;align-items:center;");
       options.operators.forEach(function(element) {
-        latexInput.parentNode.appendChild(
+        container.appendChild(
           getOperatorButton(element[0], element[1], mqField)
         );
       });
+      latexInput.parentNode.appendChild(container);
     }
 
     // don't show the old math when the tooltip gets opened next time

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -100,7 +100,7 @@
     if (options && options.operators) {
       latexInput.parentNode.appendChild(document.createElement("br"));
       var container = document.createElement("div");
-      container.setAttribute("style","display:flex;align-items:center;");
+      container.setAttribute("style", "display:flex;align-items:center;");
       options.operators.forEach(function(element) {
         container.appendChild(
           getOperatorButton(element[0], element[1], mqField)


### PR DESCRIPTION
The operator buttons before this PR contain some interesting behavior where the operator buttons would not consistently placed vertically. This error occurred with `\frac`, and maybe others but I have not tested enough to find any others. This fixes issue #7 
Old Behavior:
![59557192-a5b5f380-8f88-11e9-9763-7f993ac2a79c](https://user-images.githubusercontent.com/39388941/59557332-1b6f8e80-8f8c-11e9-8310-3fe62c16c889.png)
New Behavior:
![Screenshot_20190615_155036](https://user-images.githubusercontent.com/39388941/59557333-22969c80-8f8c-11e9-8519-3895eb86248f.png)
