### PR TITLE
Add hook for integrating with react-quill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This module adds support for rich math authoring to the [Quill](http://quilljs.c
 
 ## Usage example
 
+### Plain Javascript
+
 This module depends on [MathQuill](http://docs.mathquill.com/en/latest/Getting_Started/), [Quill](https://quilljs.com/docs/quickstart/) and [KaTeX](https://github.com/Khan/KaTeX#usage), so you'll need to add references to their JS and CSS files in addition to adding a reference to `mathquill4quill.js`. Official builds as well as minified assets can be found on the [releases page](https://github.com/c-w/mathquill4quill/releases).
 
 Next, initialize your Quill object and load the formula module:
@@ -37,6 +39,40 @@ Last step: replace Quill's native formula authoring with MathQuill.
 
 quill.enableMathQuillFormulaAuthoring();
 ```
+
+### React
+
+To integrate this module with [react-quill](https://github.com/zenoamaro/react-quill), add references to the JS and CSS files of MathQuill, KaTeX and mathquill4quill to your application. Next, you can enable the mathquill formula editor on your ReactQuill component:
+
+```javascript
+import React from 'react';
+import ReactQuill, { Quill } from 'react-quill';
+const { mathquill4quill } = window;
+
+class App extends React.Component {
+  reactQuill = React.createRef();
+
+  componentDidMount() {
+    const enableMathQuillFormulaAuthoring = mathquill4quill({ Quill });
+    enableMathQuillFormulaAuthoring(this.reactQuill.current.editor);
+  }
+
+  render() {
+    return (
+      <ReactQuill
+        ref={this.reactQuill}
+        modules={{
+          formula: true,
+          toolbar: [["formula", /* ... other toolbar items here ... */]]
+        }}
+        {/* ... other properties here ... */}
+      />
+    );
+  }
+}
+```
+
+## Optional features
 
 ### Custom operator buttons
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Last step: replace Quill's native formula authoring with MathQuill.
 ```javascript
 // enable mathquill formula editor
 
-quill.enableMathQuillFormulaAuthoring();
+var enableMathQuillFormulaAuthoring = mathquill4quill();
+enableMathQuillFormulaAuthoring(quill);
 ```
 
 ### React
@@ -79,7 +80,7 @@ class App extends React.Component {
 You can also add in operator buttons (buttons that allow users not familiar with latex to add in operators/functions like square roots) to the editor by passing an `operators` variable to the `enableMathQuillFormulaAuthoring()` function. Example:
 
 ```javascript
-quill.enableMathQuillFormulaAuthoring({
+enableMathQuillFormulaAuthoring(quill, {
   operators: [["\\sqrt[n]{x}", "\\nthroot"], ["\\frac{x}{y}","\\frac"]]
 });
 ```

--- a/index.html
+++ b/index.html
@@ -71,7 +71,9 @@
         });
       });
 
-      new Quill("#editor", quillOptions).enableMathQuillFormulaAuthoring(options);
+      var enableMathQuillFormulaAuthoring = window.mathquill4quill();
+      var quill = new Quill("#editor", quillOptions);
+      enableMathQuillFormulaAuthoring(quill, options);
 
     })(window.jQuery, window.Quill);
     </script>

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -124,6 +124,7 @@ window.mathquill4quill = function(dependencies) {
   return enableMathQuillFormulaAuthoring;
 };
 
+// for backwards compatibility with prototype-based API
 if (window.Quill) {
   window.Quill.prototype.enableMathQuillFormulaAuthoring = function(options) {
     window.mathquill4quill()(this, options);

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -1,4 +1,10 @@
-(function(Quill, MathQuill, katex) {
+window.mathquill4quill = function(dependencies) {
+  dependencies = dependencies || {};
+
+  var Quill = dependencies.Quill || window.Quill;
+  var MathQuill = dependencies.MathQuill || window.MathQuill;
+  var katex = dependencies.katex || window.katex;
+
   function insertAfter(newNode, referenceNode) {
     referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
   }
@@ -73,13 +79,13 @@
     return button;
   }
 
-  Quill.prototype.enableMathQuillFormulaAuthoring = function(options) {
-    if (!areAllDependenciesMet(this)) {
+  function enableMathQuillFormulaAuthoring(quill, options) {
+    if (!areAllDependenciesMet(quill)) {
       return;
     }
 
     // replace LaTeX formula input with MathQuill input
-    var latexInput = getTooltipLatexFormulaInput(this);
+    var latexInput = getTooltipLatexFormulaInput(quill);
     var mqInput = document.createElement("span");
     applyInputStyles(mqInput);
     insertAfter(mqInput, latexInput);
@@ -110,8 +116,16 @@
     }
 
     // don't show the old math when the tooltip gets opened next time
-    getTooltipSaveButton(this).addEventListener("click", function() {
+    getTooltipSaveButton(quill).addEventListener("click", function() {
       mqField.latex("");
     });
+  }
+
+  return enableMathQuillFormulaAuthoring;
+};
+
+if (window.Quill) {
+  window.Quill.prototype.enableMathQuillFormulaAuthoring = function(options) {
+    window.mathquill4quill()(this, options);
   };
-})(window.Quill, window.MathQuill, window.katex);
+}


### PR DESCRIPTION
This change adds a new top-level function `window.mathquill4quill` which acts as a factory method for the `enableMathQuillFormulaAuthoring` call. Decoupling the `enableMathQuillFormulaAuthoring` call from the Quill instance enables integrating the `mathquill4quill` library with other projects that are built on-top of Quill such as [react-quill](https://github.com/zenoamaro/react-quill) mentioned in https://github.com/c-w/mathquill4quill/issues/9.