### PR TITLE
Autofocus formula editor when it is opened

### DIFF
--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -108,7 +108,7 @@ window.mathquill4quill = function(dependencies) {
     //set focus to formula editor when it is opened
     document.getElementsByClassName("ql-formula")[0].onclick = function() {
       window.setTimeout(function() {
-        mqField.focus()
+        mqField.focus();
       }, 1);
     };
 

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -105,6 +105,13 @@ window.mathquill4quill = function(dependencies) {
       }
     });
 
+    //set focus to formula editor when it is opened
+    document.getElementsByClassName("ql-formula")[0].onclick = function() {
+      window.setTimeout(function() {
+        mqField.focus()
+      }, 1);
+    };
+
     if (options && options.operators) {
       latexInput.parentNode.appendChild(document.createElement("br"));
       var container = document.createElement("div");

--- a/tests.js
+++ b/tests.js
@@ -21,7 +21,6 @@ module.exports = {
   "Can an equation be inserted": function(browser) {
     browser
       .useXpath()
-      .click('//div[@data-mode="formula"]/span')
       .keys(["x", "^", "2"])
       .click('//a[@class="ql-action"]')
       .waitForElementVisible('//span[@class="ql-formula"]')


### PR DESCRIPTION
This PR fixes issue #12, by making sure that the formula editor gets focused when it is opened. I had to use a `setTimeout()` to do this because otherwise the editor would not become visible(in Chrome at least). It would be nice if there is a better solution, but the current one works well, it is just not the most optimal.