### PR TITLE
Prevent operator button from submitting a form

### DIFF
--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -155,6 +155,7 @@ window.mathquill4quill = function(dependencies) {
         var operator = element[1];
 
         var button = document.createElement("button");
+        button.setAttribute("type", "button");
 
         katex.render(displayOperator, button, {
           throwOnError: false


### PR DESCRIPTION
Set operator button type to button to prevent side effect where it triggers form submission.