### PR TITLE
Updated chromedriver version to v79

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "chromedriver": "^75.0.0",
+    "chromedriver": "^79.0.0",
     "concurrently": "^4.1.1",
     "eslint": "^5.16.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
The previous version wouldn't work with the latest version of Chrome which most people presumably have installed on their development environment.