### PR TITLE
Fix chromedriver version mismatch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-18.04'
 
 steps:
 - script: npm install
@@ -10,9 +10,6 @@ steps:
 
 - script: npm run lint
   displayName: 'Run lint'
-
-- script: sudo apt-get update && sudo apt-get install -y chromium-browser
-  displayName: 'Install Chromium for testing'
 
 - script: npm run test
   displayName: 'Run tests'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "chromedriver": "^75.0.0",
+    "chromedriver": "^78.0.0",
     "concurrently": "^4.1.1",
     "eslint": "^5.16.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "nightwatch": "^1.1.12",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
-    "release-it": "^12.3.0",
+    "release-it": "^12.4.3",
     "reload": "^3.0.1",
     "serve": "^11.0.2",
     "uglify-js": "^3.6.0"


### PR DESCRIPTION
The CI is currently failing ([see build](https://clewolff.visualstudio.com/mathquill4quill/_build/results?buildId=613)) due to a version mismatch between the latest Chrome and the version of `chromedriver` declared in `package.json`.

To fix the build and prevent future breakage, this pull request pins the version of Chrome used by the tests to version 78 which is available by default on the Ubuntu 18.04 Azure Pipelines agents ([see agent software list](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md)).

The pull request also updates the version of `release-it` to fix `npm audit` warnings.