### PR TITLE
Add minified asset to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "url": "https://github.com/c-w/mathquill4quill"
   },
   "version": "1.0.0",
+  "files": [
+    "build/mathquill4quill.min.js",
+    "mathquill4quill.js"
+  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
The package published to NPM currently contains all the files in the repository which includes a bunch of unnecessary files (e.g. the code for the demo page).

This pull request makes the listing of files published to NPM explicit to include only:
- `mathquill4quill.js`: the core library written in ES6.
- `build/mathquill4quill.min.js`: a babelified and minified version of the file for older browsers.
