### PR TITLE
Fix options.autofocus=false being discarded

### DIFF
--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -53,7 +53,7 @@ window.mathquill4quill = function(dependencies) {
     }
 
     function newMathquillInput() {
-      const autofocus = options.autofocus || true;
+      const autofocus = options.autofocus == null ? true : options.autofocus;
       let mqInput = null;
       let mqField = null;
       let latexInputStyle = null;


### PR DESCRIPTION
Currently the autofocus option can't be disabled since `options.autofocus || true` evaluates to true even if the option is explicitly set to false. Using the default value only if the provided value is null fixes the problem.