### PR TITLE
Publish test results to Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,3 +13,11 @@ steps:
 
 - script: npm run test
   displayName: 'Run tests'
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: 'JUnit'
+    testResultsFiles: '*.xml'
+    searchFolder: '$(Build.Repository.LocalPath)/tests_output'
+    mergeTestResults: true
+  condition: always()


### PR DESCRIPTION
This pull request uploads the nightwatch.js test results to Azure Pipelines for easier visualization and performance tracking.

Successful build:

![Screenshot showing Azure Pipelines test results for successful build](https://user-images.githubusercontent.com/1086421/72643844-942d3380-393d-11ea-9fef-c48c57d4d674.png)

Failed build:

![Screenshot showing Azure Pipelines test results for failed build](https://user-images.githubusercontent.com/1086421/72643853-98595100-393d-11ea-9ff9-f9cdb1e94e6c.png)
