### PR TITLE
Added support to display and save formula history.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   parserOptions: {
-    ecmaVersion: 6
+    ecmaVersion: 2018
   },
   rules: {
     "no-var": "error"

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,8 +7,8 @@
     "release": true,
     "assets": [
       "mathquill4quill.css",
+      "mathquill4quill.js",
       "build/mathquill4quill.min.css",
-      "build/mathquill4quill.js",
       "build/mathquill4quill.min.js"
     ],
     "preRelease": true

--- a/.release-it.json
+++ b/.release-it.json
@@ -6,6 +6,8 @@
   "github": {
     "release": true,
     "assets": [
+      "mathquill4quill.css",
+      "build/mathquill4quill.min.css",
       "build/mathquill4quill.js",
       "build/mathquill4quill.min.js"
     ],

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,0 +1,5 @@
+/* eslint-env node */
+
+module.exports = {
+  extends: "stylelint-config-standard"
+};

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This module adds support for rich math authoring to the [Quill](http://quilljs.c
 
 ### Plain Javascript
 
-This module depends on [MathQuill](http://docs.mathquill.com/en/latest/Getting_Started/), [Quill](https://quilljs.com/docs/quickstart/) and [KaTeX](https://github.com/Khan/KaTeX#usage), so you'll need to add references to their JS and CSS files in addition to adding a reference to `mathquill4quill.js`. Official builds as well as minified assets can be found on the [releases page](https://github.com/c-w/mathquill4quill/releases).
+This module depends on [MathQuill](http://docs.mathquill.com/en/latest/Getting_Started/), [Quill](https://quilljs.com/docs/quickstart/) and [KaTeX](https://github.com/Khan/KaTeX#usage), so you'll need to add references to their JS and CSS files in addition to adding a reference to `mathquill4quill.js` and `mathquill4quill.css`. Official builds as well as minified assets can be found on the [releases page](https://github.com/c-w/mathquill4quill/releases).
 
 Next, initialize your Quill object and load the formula module:
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ The operators variable is an array of arrays. The outside array contains all of 
 
 <img src="https://user-images.githubusercontent.com/1086421/60978823-b8a9b280-a2ff-11e9-990a-ffba2b4ff394.gif" width="450" alt="Demo of mathquill4quill with custom operator buttons">
 
+### List of previous formulas
+
+Previous formulas can be saved and re-used. The available related configurations are:
+
+```javascript
+enableMathQuillFormulaAuthoring(quill, {
+  displayHistory: true, // defaults to false
+  historyCacheKey: '__my_app_math_history_cachekey_', // optional 
+  historySize: 20 // optional (defaults to 10)
+});
+```
+
+This works by saving formula to a list (and local storage by default) everytime a new formula is used. Then displaying this list when a user opens the formula tooltip.
+
+![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31671215/75315157-c96b5200-5816-11ea-99c2-f5414ee8e241.gif)
+
 ### Autofocus
 
 For user convenience, mathquill4quill defaults to focusing the math input field when the formula button is pressed. You can disable this behavior via the `autofocus` option in the `enableMathQuillFormulaAuthoring()` function. Example:

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
 
     <!-- mathquill4quill include -->
     <script src="mathquill4quill.js"></script>
+    <link rel="stylesheet" href="mathquill4quill.css">
 
     <!-- demo page -->
     <link rel="stylesheet" href="index.css">

--- a/mathquill4quill.css
+++ b/mathquill4quill.css
@@ -1,0 +1,30 @@
+.mathquill4quill-mathquill-input {
+  border: 1px solid #ccc;
+  font-size: 13px;
+  min-height: 26px;
+  margin: 0;
+  padding: 3px 5px;
+  width: 170px;
+}
+
+.mathquill4quill-operator-button {
+  margin: 5px;
+  width: 50px;
+  height: 50px;
+  background-color: #fff;
+  border-color: #000;
+  border-radius: 7px;
+  border-width: 2px;
+}
+
+.mathquill4quill-operator-container {
+  display: flex;
+  align-items: center;
+}
+
+.mathquill4quill-latex-input {
+  visibility: hidden !important;
+  padding: 0 !important;
+  border: 0 !important;
+  width: 0 !important;
+}

--- a/mathquill4quill.css
+++ b/mathquill4quill.css
@@ -22,6 +22,35 @@
   align-items: center;
 }
 
+.mathquill4quill-history-button {
+  overflow: hidden;
+  margin: 5px;
+  width: 270px;
+  height: 65px;
+  min-height: 60px;
+  background-color: #fff;
+  border-color: #000;
+  border-radius: 7px;
+  border-width: 2px;
+  cursor: pointer;
+  transition: background-color 0.3s linear;
+  opacity: 1;
+}
+
+.mathquill4quill-history-button:hover {
+  background-color: rgb(239, 240, 241);
+  opacity: 0.7;
+}
+
+.mathquill4quill-history-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 300px;
+  height: 150px;
+  overflow: auto;
+}
+
 .mathquill4quill-latex-input {
   visibility: hidden !important;
   padding: 0 !important;

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -84,6 +84,8 @@ window.mathquill4quill = function(dependencies) {
 
     function newMathquillInput() {
       const autofocus = options.autofocus == null ? true : options.autofocus;
+      const mathQuillConfig =
+        options.mathQuillConfig != null ? options.mathQuillConfig : {};
       const cacheKey = options.cacheKey || "__mathquill4quill_cache__";
       let mqInput = null;
       let mqField = null;
@@ -98,18 +100,23 @@ window.mathquill4quill = function(dependencies) {
       }
 
       function syncMathquillToQuill(latexInput, saveButton) {
-        const mqField = MathQuill.getInterface(2).MathField(mqInput, {
-          handlers: {
-            edit() {
-              const latex = mqField.latex();
-              latexInput.value = latex;
-              setCacheItem(cacheKey, latex);
-            },
-            enter() {
-              saveButton.click();
-            }
+        const handlers =
+          mathQuillConfig.handlers == null ? {} : mathQuillConfig.handlers;
+        mathQuillConfig.handlers = {
+          ...handlers,
+          edit() {
+            const latex = mqField.latex();
+            latexInput.value = latex;
+            setCacheItem(cacheKey, latex);
+          },
+          enter() {
+            saveButton.click();
           }
-        });
+        };
+        const mqField = MathQuill.getInterface(2).MathField(
+          mqInput,
+          mathQuillConfig
+        );
 
         const cachedLatex = getCacheItem(cacheKey);
         if (cachedLatex) {

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -265,34 +265,11 @@ window.mathquill4quill = function(dependencies) {
       let historyDiv = null;
 
       function applyHistoryButtonStyles(button) {
-        button.style.overflow = "hidden";
-        button.style.margin = "5px";
-        button.style.width = "270px";
-        button.style.height = "65px";
-        button.style.minHeight = "60px";
-        button.style.backgroundColor = "#ffffff";
-        button.style.borderColor = "#000000";
-        button.style.borderRadius = "7px";
-        button.style.borderWidth = "2px";
-        button.style.cursor = "pointer";
-        button.style.transition = "background-color 0.3s linear";
-        button.onmouseenter = function() {
-          this.style.backgroundColor = "rgb(239, 240, 241)";
-          this.style.opacity = "0.7";
-        };
-        button.onmouseleave = function() {
-          this.style.backgroundColor = "#ffffff";
-          this.style.opacity = "1";
-        };
+        button.setAttribute("class", "mathquill4quill-history-button");
       }
 
       function applyHistoryContainerStyles(container) {
-        container.style.display = "flex";
-        container.style.flexDirection = "column";
-        container.style.alignItems = "center";
-        container.style.width = "300px";
-        container.style.height = "150px";
-        container.style.overflow = "auto";
+        container.setAttribute("class", "mathquill4quill-history-container");
       }
 
       function createHistoryButton(latex, mqField) {
@@ -356,7 +333,7 @@ window.mathquill4quill = function(dependencies) {
           quill.container.getBoundingClientRect().top <
         0
       ) {
-        tooltip.style.top = "38px";
+        tooltip.style.top = "0px";
       }
     }
 

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -90,19 +90,11 @@ window.mathquill4quill = function(dependencies) {
       let latexInputStyle = null;
 
       function applyMathquillInputStyles(mqInput) {
-        mqInput.style.border = "1px solid #ccc";
-        mqInput.style.fontSize = "13px";
-        mqInput.style.minHeight = "26px";
-        mqInput.style.margin = "0px";
-        mqInput.style.padding = "3px 5px";
-        mqInput.style.width = "170px";
+        mqInput.setAttribute("class", "mathquill4quill-mathquill-input");
       }
 
       function applyLatexInputStyles(latexInput) {
-        latexInput.setAttribute(
-          "style",
-          "visibility:hidden;padding:0px;border:0px;width:0px;"
-        );
+        latexInput.setAttribute("class", "mathquill4quill-latex-input");
       }
 
       function syncMathquillToQuill(latexInput, saveButton) {
@@ -178,18 +170,11 @@ window.mathquill4quill = function(dependencies) {
       let container = null;
 
       function applyOperatorButtonStyles(button) {
-        button.style.margin = "5px";
-        button.style.width = "50px";
-        button.style.height = "50px";
-        button.style.backgroundColor = "#ffffff";
-        button.style.borderColor = "#000000";
-        button.style.borderRadius = "7px";
-        button.style.borderWidth = "2px";
+        button.setAttribute("class", "mathquill4quill-operator-button");
       }
 
       function applyOperatorContainerStyles(container) {
-        container.style.display = "flex";
-        container.style.alignItems = "center";
+        container.setAttribute("class", "mathquill4quill-operator-container");
       }
 
       function createOperatorButton(element, mqField) {

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -81,7 +81,7 @@ window.mathquill4quill = function(dependencies) {
       if (item && item.length > 0) {
         const index = historyList.indexOf(item);
         if (index != -1) {
-          historyList.splice(index, 1)
+          historyList.splice(index, 1);
         }
         historyList.unshift(item);
         if (historyList.length > historySize) historyList.pop();
@@ -275,17 +275,15 @@ window.mathquill4quill = function(dependencies) {
         button.style.borderRadius = "7px";
         button.style.borderWidth = "2px";
         button.style.cursor = "pointer";
-        button.style.transition =  "background-color 0.3s linear";
-        button.onmouseenter = function() 
-        {
-            this.style.backgroundColor = "rgb(239, 240, 241)";
-            this.style.opacity = "0.7";
-        }
-        button.onmouseleave = function() 
-        {
-            this.style.backgroundColor = "#ffffff";
-            this.style.opacity = "1";
-        }
+        button.style.transition = "background-color 0.3s linear";
+        button.onmouseenter = function() {
+          this.style.backgroundColor = "rgb(239, 240, 241)";
+          this.style.opacity = "0.7";
+        };
+        button.onmouseleave = function() {
+          this.style.backgroundColor = "#ffffff";
+          this.style.opacity = "1";
+        };
       }
 
       function applyHistoryContainerStyles(container) {
@@ -314,8 +312,7 @@ window.mathquill4quill = function(dependencies) {
 
       return {
         render(mqField) {
-
-          fixToolTipHeight()
+          fixToolTipHeight();
 
           if (historyDiv != null || !displayHistory || history.length === 0) {
             return;
@@ -327,15 +324,15 @@ window.mathquill4quill = function(dependencies) {
           let container = document.createElement("div");
           applyHistoryContainerStyles(container);
           let header = document.createElement("p");
-          header.innerHTML = "Past formulas (max " + historySize + ")"
-          historyDiv.appendChild(header)
+          header.innerHTML = "Past formulas (max " + historySize + ")";
+          historyDiv.appendChild(header);
 
           history.forEach(element => {
             const button = createHistoryButton(element, mqField);
             applyHistoryButtonStyles(button);
             container.appendChild(button);
           });
-          historyDiv.appendChild(container)
+          historyDiv.appendChild(container);
           tooltip.appendChild(historyDiv);
         },
         destroy() {
@@ -352,10 +349,13 @@ window.mathquill4quill = function(dependencies) {
     // If tooltip hangs below Quill div, Quill will position tooltip in bad place if function is clicked twice
     // This addresses the position issue
     function fixToolTipHeight() {
-
       const tooltip = getTooltip();
 
-      if (tooltip.getBoundingClientRect().top - quill.container.getBoundingClientRect().top < 0) {
+      if (
+        tooltip.getBoundingClientRect().top -
+          quill.container.getBoundingClientRect().top <
+        0
+      ) {
         tooltip.style.top = "38px";
       }
     }
@@ -366,7 +366,8 @@ window.mathquill4quill = function(dependencies) {
 
     const tooltip = getTooltip();
 
-    const historyCacheKey = options.historyCacheKey || "__mathquill4quill_historylist_cache__";
+    const historyCacheKey =
+      options.historyCacheKey || "__mathquill4quill_historylist_cache__";
     let historyList = fetchHistoryList(historyCacheKey);
     const historySize = options.historySize || 10;
     const displayHistory = options.displayHistory || false;

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -77,9 +77,9 @@ window.mathquill4quill = function(dependencies) {
     }
 
     function addItemToHistoryList(key) {
-      item = getCacheItem(key);
+      const item = getCacheItem(key);
       if (item && item.length > 0) {
-        index = historyList.indexOf(item);
+        const index = historyList.indexOf(item);
         if (index != -1) {
           historyList.splice(index, 1)
         }
@@ -324,9 +324,9 @@ window.mathquill4quill = function(dependencies) {
           const tooltip = getTooltip();
 
           historyDiv = document.createElement("div");
-          container = document.createElement("div");
+          let container = document.createElement("div");
           applyHistoryContainerStyles(container);
-          header = document.createElement("p");
+          let header = document.createElement("p");
           header.innerHTML = "Past formulas (max " + historySize + ")"
           historyDiv.appendChild(header)
 
@@ -367,7 +367,7 @@ window.mathquill4quill = function(dependencies) {
     const tooltip = getTooltip();
 
     const historyCacheKey = options.historyCacheKey || "__mathquill4quill_historylist_cache__";
-    var historyList = fetchHistoryList(historyCacheKey);
+    let historyList = fetchHistoryList(historyCacheKey);
     const historySize = options.historySize || 10;
     const displayHistory = options.displayHistory || false;
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build.uglify": "uglifyjs --compress --mangle -- build/mathquill4quill.js > build/mathquill4quill.min.js",
     "build.csso": "csso --input mathquill4quill.css --output build/mathquill4quill.min.css",
     "build": "run-s build.babel build.uglify build.csso",
+    "postbuild": "rimraf build/mathquill4quill.js",
     "test": "concurrently --kill-others --success first \"serve -n -l 8000\" \"nightwatch -e chrome tests\""
   },
   "devDependencies": {
@@ -29,6 +30,7 @@
     "prettier": "^1.18.2",
     "release-it": "^12.4.3",
     "reload": "^3.0.1",
+    "rimraf": "^3.0.2",
     "serve": "^11.0.2",
     "stylelint": "^13.2.0",
     "stylelint-config-standard": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "type": "git",
     "url": "https://github.com/c-w/mathquill4quill"
   },
-  "version": "1.0.2",
+  "version": "2.0.0",
   "files": [
     "build/mathquill4quill.min.css",
     "build/mathquill4quill.min.js",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "type": "git",
     "url": "https://github.com/c-w/mathquill4quill"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "files": [
     "build/mathquill4quill.min.css",
     "build/mathquill4quill.min.js",

--- a/package.json
+++ b/package.json
@@ -5,20 +5,23 @@
     "release": "release-it",
     "start": "reload --port 8080 --browser --dir .",
     "lint.js": "eslint --ext js .",
+    "lint.css": "stylelint \"*.css\"",
     "lint.prettier": "prettier --check \"**/*.js\"",
-    "lint": "run-s lint.js lint.prettier",
+    "lint": "run-s lint.js lint.css lint.prettier",
     "prebuild": "mkdirp build",
     "build.babel": "babel mathquill4quill.js > build/mathquill4quill.js",
     "build.uglify": "uglifyjs --compress --mangle -- build/mathquill4quill.js > build/mathquill4quill.min.js",
-    "build": "run-s build.babel build.uglify",
+    "build.csso": "csso --input mathquill4quill.css --output build/mathquill4quill.min.css",
+    "build": "run-s build.babel build.uglify build.csso",
     "test": "concurrently --kill-others --success first \"serve -n -l 8000\" \"nightwatch -e chrome tests\""
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "chromedriver": "^78.0.0",
+    "chromedriver": "^80.0.0",
     "concurrently": "^4.1.1",
+    "csso-cli": "^3.0.0",
     "eslint": "^5.16.0",
     "mkdirp": "^0.5.1",
     "nightwatch": "^1.1.12",
@@ -27,6 +30,8 @@
     "release-it": "^12.4.3",
     "reload": "^3.0.1",
     "serve": "^11.0.2",
+    "stylelint": "^13.2.0",
+    "stylelint-config-standard": "^20.0.0",
     "uglify-js": "^3.6.0"
   },
   "repository": {
@@ -35,7 +40,9 @@
   },
   "version": "1.0.2",
   "files": [
+    "build/mathquill4quill.min.css",
     "build/mathquill4quill.min.js",
+    "mathquill4quill.css",
     "mathquill4quill.js"
   ],
   "publishConfig": {


### PR DESCRIPTION
For some applications, it is helpful to re-use formula or edit formula. Currently, in Quill, this is tricky to implement. However, I've added some functionality to optionally display history of formulas which makes it easy to re-use and edit recent formula.


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/31671215/75315157-c96b5200-5816-11ea-99c2-f5414ee8e241.gif)

This works by saving formula to a list (and local storage). Then displaying this list when a user opens the formula tooltip.

Additionally, I noticed a small intentional bug from Quill where if the tooltip extends outside of the Quill div, the tooltip is moved up (in a very inconvenient spot in some cases). And this is more likely to happen as more content is added to the tooltip. The tooltip is only moved this way if the function button is clicked twice for some reason.