### PR TITLE
Ensure non-minified JS is released as artifact

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -7,8 +7,8 @@
     "release": true,
     "assets": [
       "mathquill4quill.css",
+      "mathquill4quill.js",
       "build/mathquill4quill.min.css",
-      "build/mathquill4quill.js",
       "build/mathquill4quill.min.js"
     ],
     "preRelease": true


### PR DESCRIPTION
This change fixes a regression introduced in https://github.com/c-w/mathquill4quill/pull/41 which broke publishing the non-minified version of `mathquill4quill.js` as a Github release artifact.