### PR TITLE
Add demo for displayHistory option

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,15 @@
                       ["\\sum^{s}_{x}{d}", "\\sum"],["\\prod^{s}_{x}{d}", "\\prod"],["\\coprod^{s}_{x}{d}", "\\coprod"],
                       ["\\int^{s}_{x}{d}", "\\int"],["\\binom{n}{k}", "\\binom"]]'>
       </label>
+
+      <label>
+        Display formula history:
+        <input
+          type="checkbox"
+          class="option"
+          data-name="displayHistory"
+          data-value="true">
+      </label>
     </main>
   </body>
 </html>


### PR DESCRIPTION
This change adds `displayHistory` (introduced in https://github.com/c-w/mathquill4quill/pull/40) to the [live demo page](https://justamouse.com/mathquill4quill/).