### PR TITLE
Enable usage as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ enableMathQuillFormulaAuthoring(quill);
 
 ### React
 
-To integrate this module with [react-quill](https://github.com/zenoamaro/react-quill), add references to the JS and CSS files of MathQuill, KaTeX and mathquill4quill to your application. Next, you can enable the mathquill formula editor on your ReactQuill component:
+To integrate this module with [react-quill](https://github.com/zenoamaro/react-quill), add references to the JS and CSS files of MathQuill and KaTeX to your application. Next, you can enable the mathquill formula editor on your ReactQuill component:
 
 ```javascript
 import React from 'react';
 import ReactQuill, { Quill } from 'react-quill';
-const { mathquill4quill } = window;
+import mathquill4quill from 'mathquill4quill';
+import 'mathquill4quill/mathquill4quill.css';
 
 class App extends React.Component {
   reactQuill = React.createRef();

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -1,4 +1,4 @@
-/* eslint-env browser */
+/* eslint-env browser, commonjs */
 
 window.mathquill4quill = function(dependencies) {
   dependencies = dependencies || {};
@@ -378,6 +378,10 @@ window.mathquill4quill = function(dependencies) {
 
   return enableMathQuillFormulaAuthoring;
 };
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = window.mathquill4quill;
+}
 
 // for backwards compatibility with prototype-based API
 if (window.Quill) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "chromedriver": "^80.0.0",
+    "chromedriver": "^85.0.0",
     "concurrently": "^4.1.1",
     "csso-cli": "^3.0.0",
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "url": "https://github.com/c-w/mathquill4quill"
   },
   "version": "2.1.2",
+  "main": "mathquill4quill.js",
   "files": [
     "build/mathquill4quill.min.css",
     "build/mathquill4quill.min.js",


### PR DESCRIPTION
This pull request makes usage of `mathquill4quill` more ergonomic on modern stacks such as React by exposing the package as a module to enable `require` and `import` statements.