### PR TITLE
Fixed pipeline fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
-    "chromedriver": "^85.0.0",
+    "chromedriver": "^87.0.0",
     "concurrently": "^4.1.1",
     "csso-cli": "^3.0.0",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Chrome got updated to version 87 in the Ubuntu 18.04 repositories, but Chromedriver hasn't been updated in this project to be compatible. This MR simply updates Chromedriver to version 87.