### PR TITLE
Improve command operator regex

### DIFF
--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -222,6 +222,7 @@ window.mathquill4quill = function(dependencies) {
 
         const button = document.createElement("button");
         button.setAttribute("type", "button");
+        button.setAttribute("data-value", operator);
 
         katex.render(displayOperator, button, {
           throwOnError: false

--- a/mathquill4quill.js
+++ b/mathquill4quill.js
@@ -37,10 +37,7 @@ window.mathquill4quill = function(dependencies) {
   }
 
   function isOperatorCommand(operator) {
-    if (/\[|\{|\(/.test(operator)) {
-      return false;
-    }
-    return true;
+    return /^\\[A-Za-z]+$/.test(operator);
   }
 
   function enableMathQuillFormulaAuthoring(quill, options) {

--- a/tests/commandOperatorButton.test.js
+++ b/tests/commandOperatorButton.test.js
@@ -1,0 +1,25 @@
+/* eslint-env node */
+
+module.exports = {
+  "Is the formula editor visible": function(browser) {
+    browser
+      .useXpath()
+      .url("http://localhost:8000/?&operators=true")
+      .waitForElementVisible('//*[@id="editor"]')
+      .click('//button[@class="ql-formula"]')
+      .waitForElementVisible('//div[@data-mode="formula"]');
+  },
+  "Is command operator button working": function(browser) {
+    browser
+      .useXpath()
+      .click('//button[@data-value="\\sqrt"]')
+      .click('//a[@class="ql-action"]')
+      .waitForElementVisible('//span[@class="ql-formula"]')
+      .assert.attributeContains(
+        '//span[@class="ql-formula"]',
+        "data-value",
+        "\\sqrt"
+      )
+      .end();
+  }
+};

--- a/tests/commandOperatorButton.test.js
+++ b/tests/commandOperatorButton.test.js
@@ -13,6 +13,7 @@ module.exports = {
     browser
       .useXpath()
       .click('//button[@data-value="\\sqrt"]')
+      .waitForElementVisible('//span[@class="mq-scaled mq-sqrt-prefix"]')
       .click('//a[@class="ql-action"]')
       .waitForElementVisible('//span[@class="ql-formula"]')
       .assert.attributeContains(

--- a/tests/latexOperatorButton.test.js
+++ b/tests/latexOperatorButton.test.js
@@ -1,0 +1,25 @@
+/* eslint-env node */
+
+module.exports = {
+  "Is the formula editor visible": function(browser) {
+    browser
+      .useXpath()
+      .url("http://localhost:8000/?&operators=true")
+      .waitForElementVisible('//*[@id="editor"]')
+      .click('//button[@class="ql-formula"]')
+      .waitForElementVisible('//div[@data-mode="formula"]');
+  },
+  "Is latex string button working": function(browser) {
+    browser
+      .useXpath()
+      .click('//button[@data-value="\\sqrt[3]{}"]')
+      .click('//a[@class="ql-action"]')
+      .waitForElementVisible('//span[@class="ql-formula"]')
+      .assert.attributeContains(
+        '//span[@class="ql-formula"]',
+        "data-value",
+        "\\sqrt[3]{}"
+      )
+      .end();
+  }
+};

--- a/tests/latexOperatorButton.test.js
+++ b/tests/latexOperatorButton.test.js
@@ -13,6 +13,7 @@ module.exports = {
     browser
       .useXpath()
       .click('//button[@data-value="\\sqrt[3]{}"]')
+      .waitForElementVisible('//sup[@class="mq-nthroot mq-non-leaf"]')
       .click('//a[@class="ql-action"]')
       .waitForElementVisible('//span[@class="ql-formula"]')
       .assert.attributeContains(


### PR DESCRIPTION
I just realized that the original regex only allowed things like `\\sqrt[3]{}` but not `\\int_x^y`, so I just simplified the regex to detect \\ followed by just letters
